### PR TITLE
Adding profiles for tar executable path

### DIFF
--- a/karaf-edi/pom.xml
+++ b/karaf-edi/pom.xml
@@ -28,21 +28,24 @@
 	<url>https://www.mescedia.com</url>
 	<name>mescedia :: Open Source EDI server [apache-karaf] </name>
 	
+	<properties>
+		<karaf.version>4.0.8</karaf.version>
+  		<mysql.version>5.1.34</mysql.version>
+		<smooks.version>1.6</smooks.version>
+  		<hawtio.version>1.4.66</hawtio.version>
+		<camel.version>2.16.4</camel.version>
+  		<activemq.version>5.14.1</activemq.version>	
+		<install.target>${basedir}/target/dependencies</install.target>
+		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>  		
+	</properties>
+	
 	<profiles>
   		<profile>
   			<id>default</id>
   			<activation>
-      			<activeByDefault>true</activeByDefault>
-    		</activation>
+      				<activeByDefault>true</activeByDefault>
+    			</activation>
 		  	<properties>
-		  		<karaf.version>4.0.8</karaf.version>
-		  		<mysql.version>5.1.34</mysql.version>
-		  		<smooks.version>1.6</smooks.version>
-		  		<hawtio.version>1.4.66</hawtio.version>
-		  		<camel.version>2.16.4</camel.version>
-		  		<activemq.version>5.14.1</activemq.version>		
-		  		<install.target>${basedir}/target/dependencies</install.target>
-		  		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>
 		  		<exec.path>/bin</exec.path>
 		  	</properties>
 	  	</profile>
@@ -50,14 +53,6 @@
 	  	<profile>
 	  		<id>macOS</id>
 		  	<properties>
-		  		<karaf.version>4.0.8</karaf.version>
-		  		<mysql.version>5.1.34</mysql.version>
-		  		<smooks.version>1.6</smooks.version>
-		  		<hawtio.version>1.4.66</hawtio.version>
-		  		<camel.version>2.16.4</camel.version>
-		  		<activemq.version>5.14.1</activemq.version>		
-		  		<install.target>${basedir}/target/dependencies</install.target>
-		  		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>
 		  		<exec.path>/usr/bin</exec.path>
 		  	</properties>
 	  	</profile>

--- a/karaf-edi/pom.xml
+++ b/karaf-edi/pom.xml
@@ -28,16 +28,40 @@
 	<url>https://www.mescedia.com</url>
 	<name>mescedia :: Open Source EDI server [apache-karaf] </name>
 	
-	<properties>
-		<karaf.version>4.0.8</karaf.version>
-		<mysql.version>5.1.34</mysql.version>
-		<smooks.version>1.6</smooks.version>
-		<hawtio.version>1.4.66</hawtio.version>
-		<camel.version>2.16.4</camel.version>
-		<activemq.version>5.14.1</activemq.version>		
-		<install.target>${basedir}/target/dependencies</install.target>
-		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>
-	</properties>
+	<profiles>
+  		<profile>
+  			<id>default</id>
+  			<activation>
+      			<activeByDefault>true</activeByDefault>
+    		</activation>
+		  	<properties>
+		  		<karaf.version>4.0.8</karaf.version>
+		  		<mysql.version>5.1.34</mysql.version>
+		  		<smooks.version>1.6</smooks.version>
+		  		<hawtio.version>1.4.66</hawtio.version>
+		  		<camel.version>2.16.4</camel.version>
+		  		<activemq.version>5.14.1</activemq.version>		
+		  		<install.target>${basedir}/target/dependencies</install.target>
+		  		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>
+		  		<exec.path>/bin</exec.path>
+		  	</properties>
+	  	</profile>
+
+	  	<profile>
+	  		<id>macOS</id>
+		  	<properties>
+		  		<karaf.version>4.0.8</karaf.version>
+		  		<mysql.version>5.1.34</mysql.version>
+		  		<smooks.version>1.6</smooks.version>
+		  		<hawtio.version>1.4.66</hawtio.version>
+		  		<camel.version>2.16.4</camel.version>
+		  		<activemq.version>5.14.1</activemq.version>		
+		  		<install.target>${basedir}/target/dependencies</install.target>
+		  		<install.archive>apache-karaf-${karaf.version}.tar.gz</install.archive>
+		  		<exec.path>/usr/bin</exec.path>
+		  	</properties>
+	  	</profile>
+  	</profiles>
 		
 	<dependencies>
 		<dependency>
@@ -649,7 +673,7 @@
 					  <argument>-C</argument>
 					  <argument>${install.target}</argument>					  
 					</arguments>		  					
-					<executable>/bin/tar</executable>
+					<executable>${exec.path}/tar</executable>
 			      </configuration>
 			    </execution>				
 			  </executions>


### PR DESCRIPTION
Fixes #1 

In macOS the exec is found in `/usr/bin/` not `/bin`. Default profile is active by default. To run macOS profile run `mvn -P macOS clean install`.